### PR TITLE
Bump json bound

### DIFF
--- a/tracetree.cabal
+++ b/tracetree.cabal
@@ -52,7 +52,7 @@ library
   build-depends:       base         >= 4.8 && < 5,
                        bifunctors   >= 4.2 && < 5.6,
                        containers   >= 0.5 && < 0.6,
-                       json         >= 0.9 && < 0.10,
+                       json         >= 0.9 && < 0.11,
                        mtl          >= 2.2 && < 2.3,
                        transformers >= 0.4 && < 0.6
   hs-source-dirs:      src


### PR DESCRIPTION
Already edited on hackage. This lets it build with more recent ghcs.