### PR TITLE
Enable compilation with 9.8

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+allow-newer: diagrams-cairo:base, SVGFonts:containers, SVGFonts:diagrams-core

--- a/src/Debug/Trace/Tree/Assoc.hs
+++ b/src/Debug/Trace/Tree/Assoc.hs
@@ -47,4 +47,8 @@ instance Semigroup (Assoc k v) where
 
 instance Monoid (Assoc k v) where
   mempty = Assoc mempty
+#if MIN_VERSION_base(4,9,0)
+  mappend = (<>)
+#else
   (Assoc xs) `mappend` (Assoc ys) = Assoc (xs `mappend` ys)
+#endif

--- a/tracetree.cabal
+++ b/tracetree.cabal
@@ -50,11 +50,11 @@ library
   -- We need ghc 7.10 (using bidrectional pattern synonyms),
   -- but I don't know how to specify that other through the version of base
   build-depends:       base         >= 4.8 && < 5,
-                       bifunctors   >= 4.2 && < 5.6,
-                       containers   >= 0.5 && < 0.6,
+                       bifunctors   >= 4.2 && < 5.7,
+                       containers   >= 0.5 && < 0.8,
                        json         >= 0.9 && < 0.11,
-                       mtl          >= 2.2 && < 2.3,
-                       transformers >= 0.4 && < 0.6
+                       mtl          >= 2.2 && < 2.4,
+                       transformers >= 0.4 && < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -84,13 +84,14 @@ executable ttrender
   if flag(ttrender)
     build-depends:     base                 >= 4.8  && < 5,
                        colour               >= 2.3  && < 2.4,
-                       json                 >= 0.9  && < 0.10,
-                       optparse-applicative >= 0.11 && < 0.15,
-                       regex-posix          >= 0.95 && < 0.96,
+                       json                 >= 0.9  && < 0.11,
+                       optparse-applicative >= 0.11 && < 0.19,
+                       regex-posix          >= 0.95 && < 0.97,
                        parsec               >= 3.1  && < 3.2,
                        diagrams-cairo       >= 1.3  && < 1.5,
                        diagrams-lib         >= 1.3  && < 1.5,
                        diagrams-contrib     >= 1.3  && < 1.5,
+                       -- lots of breaking changes in 1.7 and 1.8...
                        SVGFonts             >= 1.5  && < 1.7,
                        -- whatever version we use above
                        tracetree

--- a/ttrender/Debug/Trace/Tree/Render/Edged.hs
+++ b/ttrender/Debug/Trace/Tree/Render/Edged.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Debug.Trace.Tree.Render.Edged (renderTree) where
 
 import Data.Bifunctor
@@ -105,9 +106,18 @@ renderCoords Coords{..} =
 
 newtype Arrows = Arrows { addArrows :: Diagram B -> Diagram B }
 
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup Arrows where
+  Arrows f <> Arrows g = Arrows (f . g)
+#endif
+
 instance Monoid Arrows where
   mempty = Arrows id
+#if MIN_VERSION_base(4,9,0)
+  mappend = (<>)
+#else
   Arrows f `mappend` Arrows g = Arrows (f . g)
+#endif
 
 -- based on 'connectOutside'
 connectLabelled :: ArrowOpts Double -> Diagram B -> Bool -> Int -> Int -> Arrows


### PR DESCRIPTION
Unfortunately, I couldn't bump the SVGFonts to 1.7 nor 1.8 because they include too many breaking changes. We work around the older version's constraints by allowing-newer in the cabal.project...